### PR TITLE
IP-241 - Add pre-commit CI/CD.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+  autofix_prs: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ review and `git add` the changes before you can make a commit.
 It is planned to implement additional hooks, possibly including tools such as
 `mypy`.
 
+[pre-commit.ci](pre-commit.ci) is configured such that these same hooks will be
+automatically run for every pull request.
+
 ## Releasing a new version of the service:
 
 Once a new Docker image has been published with a new semantic version tag,


### PR DESCRIPTION
## Description

This PR is to add [pre-commit.ci](https://pre-commit.ci/) to HyBIG, which will automatically run our `pre-commit` hooks for each PR. I've configured it to _not_ automatically add a new commit with the changes, because it feels better to still have a human in the loop to review those changes.

Steps to set this up:

1) Log in to [pre-commit.ci](pre-commit.ci).
2) Select repositories for which I (or the person doing this) is an administrator, and add them to `pre-commit.ci`.
3) Update the `.pre-commit-config.yaml` to add the `ci` section.
4) Feel pleased about life.

## Jira Issue ID

N/A

## Local Test Steps

N/A

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`docker/service_version.txt` updated if publishing a release.~~
* ~~Tests added/updated and passing.~~
* [x] Documentation updated (if needed).