### PR TITLE
DAS-extra:  UPDATE .snyk to use python 3.11 / remove conda_requirements from snyk scans

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,4 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.0
 language-settings:
-  python: "3.7"
+  python: "3.11"


### PR DESCRIPTION
## Description

updates .snyk file to use python 3.11 like the codebase and verifies that `conda_requirements.txt` is removed from snyk testing.

## Testing
Look at the test results to verify.
