### PR TITLE
DAS-2180: Build process needs build package.

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -83,6 +83,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install build package
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
       - name: Build hybig-py package
         run: python -m build
 


### PR DESCRIPTION
## Description

This should fix the build pacakge.

## Jira Issue ID

[DAS-2180](https://bugs.earthdata.nasa.gov/browse/DAS-2180)

## Local Test Steps

None. Just hope.

commented out some code and ran act 

```bash

[Publish Harmony Browse Image Generator (HyBIG)/build_and_publish]   ✅  Success - Main Install build package
[Publish Harmony Browse Image Generator (HyBIG)/build_and_publish] ⭐ Run Main Build hybig-py package
[Publish Harmony Browse Image Generator (HyBIG)/build_and_publish]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/5] user= workdir=
| * Creating isolated environment: venv+pip...
| * Installing packages in isolated environment:
|   - hatch-requirements-txt
|   - hatchling
| * Getting build dependencies for sdist...
| * Building sdist...
| * Building wheel from sdist
| * Creating isolated environment: venv+pip...
| * Installing packages in isolated environment:
|   - hatch-requirements-txt
|   - hatchling
| * Getting build dependencies for wheel...
| * Building wheel...
| Successfully built hybig_py-2.0.0.tar.gz and hybig_py-2.0.0-py3-none-any.whl
```


## PR Acceptance Checklist
* [n/a] Jira ticket acceptance criteria met.
* [n/a] `CHANGELOG.md` updated to include high level summary of PR changes.
* [n/a] `docker/service_version.txt` updated if publishing a release.
* [n/a] Tests added/updated and passing.
* [n/a] Documentation updated (if needed).
