### PR TITLE
GITC-7189: Rough start at implementing no rasterizing 1-band images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 * NODATA and TRANSPARENT values are merged. [[#41](https://github.com/nasa/harmony-browse-image-generator/pull/41)]
-  - User visible change: paletted PNG outupt images will have up to 254 color
+  - User visible change: paletted PNG output images will have up to 254 color
     values and a 255th value that is transparent.
   - Internal code changes: removes `TRANSPARENT_IDX` (254) and uses
-    `NODATA_IDX` (255) in its stead.  A color of (0,0,0,0) was previosly set to
-    both the indexes (254 and 255) in the ouput PNGs and now only 255 will have
-    this value. This change ensures the roundtrip from single band to RGBA to
-    paletted PNG is consistent.
+    `NODATA_IDX` (255) in its stead.  A color of (0,0,0,0) was previously set to
+    both the indexes (254 and 255) in the output PNGs and now only 255 will have
+    this value. This change ensures the round-trip from single band to RGBA to
+    Paletted PNG is consistent.
 
 ## [v2.1.0] - 2024-12-13
 

--- a/hybig/browse.py
+++ b/hybig/browse.py
@@ -401,7 +401,7 @@ def palettize_raster(raster: ndarray) -> tuple[ndarray, dict]:
     written to the final raster as 254 and add the mapped RGBA value to the
     color palette.
     """
-    # reserves 255 for transparent and off grid fill values
+    # reserves index 255 for transparent and off grid fill values
     # 0 to 254
     max_colors = 255
     rgb_raster, alpha = remove_alpha(raster)
@@ -442,6 +442,10 @@ def get_color_map_from_image(image: Image) -> dict:
     for idx, color_tuple in enumerate(color_tuples):
         color_map[idx] = tuple(color_tuple)
     return color_map
+
+
+def get_colormap_from_scaled_colors(scaled_colors) -> dict:
+    pass
 
 
 def get_aux_xml_filename(image_filename: Path) -> Path:

--- a/hybig/browse.py
+++ b/hybig/browse.py
@@ -181,14 +181,12 @@ def create_browse_imagery(
             elif rio_in_array.rio.count in (3, 4):
                 raster = convert_mulitband_to_raster(rio_in_array)
                 color_map = None
+                if output_driver == 'JPEG':
+                    raster = raster[0:3, :, :]
             else:
                 raise HyBIGError(
                     f'incorrect number of bands for image: {rio_in_array.rio.count}'
                 )
-
-            raster, color_map = standardize_raster_for_writing(
-                raster, output_driver, color_map
-            )
 
             grid_parameters = get_target_grid_parameters(message, rio_in_array)
             grid_parameter_list, tile_locators = create_tiled_output_parameters(
@@ -410,35 +408,6 @@ def image_driver(mime: str) -> str:
     if re.search('jpeg', mime, re.I):
         return 'JPEG'
     return 'PNG'
-
-
-def standardize_raster_for_writing(
-    raster: ndarray,
-    driver: str,
-    color_map: ColorMap | None,
-) -> tuple[ndarray]:
-    """Standardize raster data for writing to browse image.
-
-    Args:
-        raster: Input raster data array
-        driver: Output image format ('JPEG' or 'PNG')
-        band_count: Number of bands in original input data
-
-    The function handles two special cases:
-    - JPEG output with 4-band data -> Drop alpha channel and return 3-band RGB
-    - PNG output with single-band data -> Convert to paletted format
-
-    Returns:
-        tuple: (prepared_raster, color_map) where:
-            - prepared_raster is the processed ndarray
-            - color_map is either None or a dict mapping palette indices to RGBA values
-
-
-    """
-    if driver == 'JPEG' and raster.shape[0] == 4:
-        return raster[0:3, :, :], color_map
-
-    return raster, color_map
 
 
 def palettize_raster(raster: ndarray) -> tuple[ndarray, dict]:


### PR DESCRIPTION
## Description

This is the rough start at how I would fix DAS-2280.  I didn't have enough time to get to fixing the unit and regression tests. But I think the code is working for 1band + colormap and the 1band with no colors is also generating grayscale images.  I'm not 100% sure those are equal to how they were before, but now they are normalized linearly from min and max values to 0-254 

## Jira Issue ID
 
renamed
~[DAS-2280](https://bugs.earthdata.nasa.gov/browse/DAS-2280)~ 
[GITC-7189](https://bugs.earthdata.nasa.gov/browse/GITC-7189)

## Local Test Steps

Not ready for testing.


## PR Acceptance Checklist
* [ ] Jira ticket acceptance criteria met.
* [ ] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] `docker/service_version.txt` updated if publishing a release.
* [ ] Tests added/updated and passing.
* [ ] Documentation updated (if needed).
