### PR TITLE
TRT-315: Add commit history to release notes.

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -40,9 +40,9 @@ jobs:
 
     steps:
       - name: Checkout harmony-browse-image-generator repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
-          lfs: true
+          fetch-depth: 0
 
       - name: Extract semantic version number
         run: echo "semantic_version=$(cat docker/service_version.txt)" >> $GITHUB_ENV

--- a/.github/workflows/run_lib_tests.yml
+++ b/.github/workflows/run_lib_tests.yml
@@ -14,9 +14,7 @@ jobs:
 
     steps:
       - name: Checkout harmony-browse-image-generator repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/run_service_tests.yml
+++ b/.github/workflows/run_service_tests.yml
@@ -16,9 +16,7 @@ jobs:
 
     steps:
       - name: Checkout harmony-browse-image-generator repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
+        uses: actions/checkout@v5
 
       - name: Build service image
         run: ./bin/build-image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ HyBIG follows semantic versioning. All notable changes to this project will be
 documented in this file. The format is based on [Keep a
 Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [2.4.1] - 2025-06-23
+## [vX.Y.Z] - Unreleased
+
+### Changed
+
+* GitHub release notes for HyBIG will now include the commit history for that
+  release.
+
+## [v2.4.1] - 2025-06-23
 
 ### Changed
 
@@ -125,6 +132,7 @@ For more information on internal releases prior to NASA open-source approval,
 see legacy-CHANGELOG.md.
 
 [unreleased]: https://github.com/nasa/harmony-browse-image-generator/
+[v2.4.1]: https://github.com/nasa/harmony-browse-image-generator/releases/tag/2.4.1
 [v2.4.0]: https://github.com/nasa/harmony-browse-image-generator/releases/tag/2.4.0
 [v2.3.0]: https://github.com/nasa/harmony-browse-image-generator/releases/tag/2.3.0
 [v2.2.0]: https://github.com/nasa/harmony-browse-image-generator/releases/tag/2.2.0

--- a/bin/extract-release-notes.sh
+++ b/bin/extract-release-notes.sh
@@ -8,6 +8,7 @@
 # 2023-10-10: Copied from earthdata-varinfo repository to HOSS.
 # 2024-01-03: Copied from HOSS repository to the Swath Projector.
 # 2024-01-23: Copied and modified from Swath Projector repository to HyBIG.
+# 2025-09-24: Append git commit messages to release notes.
 #
 ###############################################################################
 
@@ -19,13 +20,34 @@ CHANGELOG_FILE="CHANGELOG.md"
 VERSION_PATTERN="^## [\[]v"
 
 ## captures url links
-## [unreleased]:https://github.com/nasa/harmony-browse-image-generator/compare/1.2.0..HEAD
-## [v1.2.0]: https://github.com/nasa/harmony-browse-image-generator/compare/1.1.0..1.2.0
-LINK_PATTERN="^\[.*\].*\.\..*"
+## [v1.2.0]: https://github.com/nasa/harmony-browse-image-generator/releases/tags/1.2.0
+LINK_PATTERN="^\[.*\]:.*https://github.com/nasa"
 
 # Read the file and extract text between the first two occurrences of the
 # VERSION_PATTERN
 result=$(awk "/$VERSION_PATTERN/{c++; if(c==2) exit;} c==1" "$CHANGELOG_FILE")
 
+# Get all commit messages since the last release (marked with a git tag). If
+# there are no tags, get the full commit history of the repository.
+if [[ $(git tag) ]]
+then
+	# There are git tags, so get the most recent one
+	GIT_REF=$(git describe --tags --abbrev=0)
+else
+	# There are not git tags, so get the initial commit of the repository
+	GIT_REF=$(git rev-list --max-parents=0 HEAD)
+fi
+
+# Retrieve the title line of all commit messages since $GIT_REF, filtering out
+# those from the pre-commit-ci[bot] author and any containing the string
+# "nasa/pre-commit-ci-update-config", which may result from merge commits.
+GIT_COMMIT_MESSAGES=$(git log --oneline --format="%s" --perl-regexp --author='^(?!pre-commit-ci\[bot\]).*$' --grep="nasa\/pre-commit-ci-update-config" --invert-grep ${GIT_REF}..HEAD)
+
+# Append git commit messages to the release notes:
+if [[ ${GIT_COMMIT_MESSAGES} ]]
+then
+	result+="\n\n## Commits\n\n${GIT_COMMIT_MESSAGES}"
+fi
+
 # Print the result
-echo "$result" |  grep -v "$VERSION_PATTERN" | grep -v "$LINK_PATTERN"
+echo -e "$result" |  grep -v "$VERSION_PATTERN" | grep -v "$LINK_PATTERN"


### PR DESCRIPTION
## Description

This PR is (hopefully) the last in a series to add the commit history for a release to that GitHub release. As noted in a couple of places (by me and others) it would be nice to capture this script (or an equivalent) in a single place, to simplify future updates. For now, though, folks at a couple of the DAACs have expressed a need to more easily track what work is in each release by Jira ticket number. As commit messages are prepended with ticket numbers, this change allows that tracking.

## Jira Issue ID

TRT-315 and other DAAC verification features.

## Local Test Steps

* Pull this branch.
* Run `./bin/extract-release-notes.sh`. You should see the content from the most recent `CHANGELOG.md` entry followed by a commit history.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* ~~`docker/service_version.txt` updated if publishing a release.~~ Updated to CI/CD only
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~