### PR TITLE
GITC-8962: Memory and performance optimization when reading data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ HyBIG follows semantic versioning. All notable changes to this project will be
 documented in this file. The format is based on [Keep a
 Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+* [GITC-8962](https://bugs.earthdata.nasa.gov/browse/GITC-8962): Memory and performance optimization for reading data from source when width and height or scale size parameters are not the full resolution of the data.
+
 ## [v2.6.2] - 2026-04-14
 
 ### Changed

--- a/hybig/browse.py
+++ b/hybig/browse.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import numpy as np
 import rasterio
-from affine import dumpsw
+from affine import Affine, dumpsw
 from harmony_service_lib.message import Message as HarmonyMessage
 from harmony_service_lib.message import Source as HarmonySource
 from matplotlib.colors import BoundaryNorm, Normalize
@@ -221,10 +221,31 @@ def process_tile(
     if src_window is None:
         return
 
-    # Explicitly load a subset of ds
-    tile_source = read_window_with_mask_and_scale(src_ds, src_window)
+    # Compute downsampled read dimensions: read at output resolution rather than
+    # full source resolution, avoiding loading the entire source into memory when
+    # the output is much smaller than the source (e.g. height=1280, width=2560).
+    src_pixel_x = abs(src_ds.transform.a)
+    src_pixel_y = abs(src_ds.transform.e)
+    dst_pixel_x = abs(grid_params['transform'].a)
+    dst_pixel_y = abs(grid_params['transform'].e)
+
+    win_height = int(src_window.height)
+    win_width = int(src_window.width)
+
+    # Cap at full window size so we never upsample during the read.
+    read_width = min(win_width, max(1, round(win_width * src_pixel_x / dst_pixel_x)))
+    read_height = min(win_height, max(1, round(win_height * src_pixel_y / dst_pixel_y)))
+
+    # Explicitly load a subset of ds at the target resolution
+    tile_source = read_window_with_mask_and_scale(
+        src_ds, src_window, out_shape=(band_count, read_height, read_width)
+    )
     src_crs = src_ds.crs
-    src_transform = src_ds.window_transform(src_window)
+    # Adjust the window transform to reflect the downsampled pixel size.
+    window_transform = src_ds.window_transform(src_window)
+    src_transform = window_transform * Affine.scale(
+        win_width / read_width, win_height / read_height
+    )
 
     dst_nodata = TRANSPARENT
 
@@ -355,6 +376,7 @@ def read_window_with_mask_and_scale(
     src_ds: DatasetReader,
     window: Window,
     bands: list[int] | None = None,
+    out_shape: tuple[int, int, int] | None = None,
 ) -> NDArray:
     """Read a window from a rasterio dataset with masking and scaling applied.
 
@@ -363,7 +385,10 @@ def read_window_with_mask_and_scale(
     if bands is None:
         bands = list(range(1, src_ds.count + 1))
 
-    data = src_ds.read(bands, window=window)
+    if out_shape is not None:
+        data = src_ds.read(bands, window=window, out_shape=out_shape)
+    else:
+        data = src_ds.read(bands, window=window)
 
     # Convert to float for NaN support
     data = data.astype('float64')

--- a/tests/unit/test_browse.py
+++ b/tests/unit/test_browse.py
@@ -25,6 +25,8 @@ from hybig.browse import (
     get_tiled_filename,
     output_image_file,
     output_world_file,
+    process_tile,
+    read_window_with_mask_and_scale,
     validate_file_crs,
     validate_file_type,
 )
@@ -36,6 +38,7 @@ from hybig.color_utility import (
     palette_from_remote_colortable,
 )
 from hybig.exceptions import HyBIGError
+from hybig.sizes import GridParams
 from tests.unit.utility import rasterio_test_file
 
 
@@ -292,6 +295,170 @@ class TestBrowse(TestCase):
             (self.tmp_dir / 'input_file_path.jpg.aux.xml').resolve(),
             actual_aux.resolve(),
         )
+
+    def test_read_window_with_mask_and_scale_passes_out_shape(self):
+        """Test that the out_shape parameter is forwarded to src_ds.read."""
+        ds = Mock(spec=DatasetReader)
+        window = MagicMock()
+        ds.read.return_value = np.ones((1, 2, 4), dtype='float64')
+        ds.count = 1
+        ds.nodatavals = (None,)
+        ds.scales = (1,)
+        ds.offsets = (0,)
+
+        out_shape = (1, 2, 4)
+        result = read_window_with_mask_and_scale(ds, window, out_shape=out_shape)
+
+        ds.read.assert_called_once_with([1], window=window, out_shape=out_shape)
+        self.assertEqual(result.shape, (1, 2, 4))
+
+    def test_read_window_with_mask_and_scale_without_out_shape(self):
+        """Test that without out_shape, src_ds.read is called without it."""
+        ds = Mock(spec=DatasetReader)
+        window = MagicMock()
+        ds.read.return_value = np.ones((1, 4, 4), dtype='float64')
+        ds.count = 1
+        ds.nodatavals = (None,)
+        ds.scales = (1,)
+        ds.offsets = (0,)
+
+        result = read_window_with_mask_and_scale(ds, window)
+
+        ds.read.assert_called_once_with([1], window=window)
+        self.assertEqual(result.shape, (1, 4, 4))
+
+    @patch('hybig.browse.reproject')
+    @patch('rasterio.open')
+    def test_process_tile_downsamples_read_for_coarser_output(
+        self, rasterio_open_mock, reproject_mock
+    ):
+        """Test process_tile reads at output resolution when output is coarser
+        than source.
+
+        This is the memory fix: a 36000x18000 source with a 1280x2560 output
+        should not load the full-resolution source into memory.
+        """
+        # Source: 1° pixels, 10x10
+        src_affine = Affine(1.0, 0.0, -5.0, 0.0, -1.0, 5.0)
+        ds = Mock(spec=DatasetReader)
+        ds.crs = CRS.from_string('EPSG:4326')
+        ds.transform = src_affine
+        ds.shape = (10, 10)
+        ds.count = 1
+        ds.nodatavals = (None,)
+        ds.scales = (1,)
+        ds.offsets = (0,)
+        # Return data at the downsampled (2x2) size
+        ds.read.return_value = np.array([[[0, 100], [200, 255]]], dtype='float64')
+        ds.window_transform.return_value = src_affine
+
+        dest_write_mock = Mock(spec=DatasetWriter)
+        rasterio_open_mock.return_value.__enter__.return_value = dest_write_mock
+
+        # Output: 5° pixels, 2x2 — coarser than source
+        out_affine = Affine(5.0, 0.0, -5.0, 0.0, -5.0, 5.0)
+        grid_params = GridParams(
+            {
+                'height': 2,
+                'width': 2,
+                'crs': CRS.from_string('EPSG:4326'),
+                'transform': out_affine,
+            }
+        )
+
+        process_tile(
+            ds,
+            grid_params,
+            None,
+            'PNG',
+            self.tmp_dir / 'output.png',
+            self.tmp_dir / 'output.pgw',
+            self.logger,
+        )
+
+        # Source window covers the full 10x10 source (with buffer, clamped).
+        # read_width  = min(10, round(10 * 1.0 / 5.0)) = 2
+        # read_height = min(10, round(10 * 1.0 / 5.0)) = 2
+        ds.read.assert_called_once()
+        read_kwargs = ds.read.call_args.kwargs
+        self.assertIn('out_shape', read_kwargs)
+        _bands, read_height, read_width = read_kwargs['out_shape']
+        self.assertEqual(read_width, 2)
+        self.assertEqual(read_height, 2)
+
+        # src_transform passed to reproject must have 5° pixel size (scaled from 1°)
+        self.assertEqual(reproject_mock.call_count, 1)
+        actual_src_transform = reproject_mock.call_args.kwargs['src_transform']
+        self.assertAlmostEqual(actual_src_transform.a, 5.0)
+        self.assertAlmostEqual(abs(actual_src_transform.e), 5.0)
+        self.assertAlmostEqual(actual_src_transform.c, -5.0)  # origin unchanged
+
+    @patch('hybig.browse.reproject')
+    @patch('rasterio.open')
+    def test_process_tile_full_res_when_resolutions_match(
+        self, rasterio_open_mock, reproject_mock
+    ):
+        """Test process_tile reads at full resolution when source matches
+        output resolution.
+        """
+        src_affine = Affine(90.0, 0.0, -180.0, 0.0, -45.0, 90.0)
+        ds = Mock(spec=DatasetReader)
+        ds.crs = CRS.from_string('EPSG:4326')
+        ds.transform = src_affine
+        ds.shape = (4, 4)
+        ds.count = 1
+        ds.nodatavals = (None,)
+        ds.scales = (1,)
+        ds.offsets = (0,)
+        ds.read.return_value = np.array(
+            [
+                [
+                    [0, 85, 170, 255],
+                    [0, 85, 170, 255],
+                    [0, 85, 170, 255],
+                    [0, 85, 170, 255],
+                ]
+            ],
+            dtype='float64',
+        )
+        ds.window_transform.return_value = src_affine
+
+        dest_write_mock = Mock(spec=DatasetWriter)
+        rasterio_open_mock.return_value.__enter__.return_value = dest_write_mock
+
+        # Output: same 90°/45° pixels as source — no downsampling expected
+        grid_params = GridParams(
+            {
+                'height': 4,
+                'width': 4,
+                'crs': CRS.from_string('EPSG:4326'),
+                'transform': src_affine,
+            }
+        )
+
+        process_tile(
+            ds,
+            grid_params,
+            None,
+            'PNG',
+            self.tmp_dir / 'output.png',
+            self.tmp_dir / 'output.pgw',
+            self.logger,
+        )
+
+        # read_width  = min(4, round(4 * 90/90)) = 4  (no downsampling)
+        # read_height = min(4, round(4 * 45/45)) = 4
+        ds.read.assert_called_once()
+        read_kwargs = ds.read.call_args.kwargs
+        self.assertIn('out_shape', read_kwargs)
+        _bands, read_height, read_width = read_kwargs['out_shape']
+        self.assertEqual(read_width, 4)
+        self.assertEqual(read_height, 4)
+
+        # src_transform should be unchanged (scale factor of 1.0)
+        self.assertEqual(reproject_mock.call_count, 1)
+        actual_src_transform = reproject_mock.call_args.kwargs['src_transform']
+        self.assertEqual(actual_src_transform, src_affine)
 
     def test_convert_singleband_to_raster_without_colortable(self):
         """Tests scale_grey_1band."""


### PR DESCRIPTION
## Description

Change the way that data is read from the source dataset to be more memory efficient. This is intended to address an out of memory error when specifying `height` and `width` (or `scaleSize`) in the API parameters.

Example:
`https://harmony.uat.earthdata.nasa.gov/C1238621141-POCLOUD/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&label=harmony-py&granuleId=G1281443657-POCLOUD&format=image/png&variable=analysed_sst`
this request is successful, tiled imagery is produced from the 36000x18000 source tiff. Max memory usage is <2GB

`https://harmony.uat.earthdata.nasa.gov/C1238621141-POCLOUD/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&label=harmony-py&granuleId=G1281443687-POCLOUD&format=image/tiff&variable=analysed_sst&height=1280&width=2560`
this request fails, HyBIG container runs out of memory. In local testing I found that RAM use spiked to 18 GB.

This is counterintuitive, why would the container run out of memory when producing _smaller_ output images? Basically, the rasterio code to read from the source [read whatever the src_window was](https://github.com/nasa/harmony-browse-image-generator/blob/main/hybig/browse.py#L366), so in the second case the whole tiff gets loaded into memory. 

This change addresses that and the new memory usage to handle the second request is 240MB. Everything runs faster to boot!

I won't put this into a release right away since there's no urgent need for it.

## Jira Issue ID

[GITC-8962](https://bugs.earthdata.nasa.gov/browse/GITC-8962)

## Local Test Steps

* Tested MUR and MUR25 data manually with a local harmony cluster and compared against 2.6.2 imagery, they are identical
* Ran harmony regression test notebook, the opera-rtc-s1 and scaleSize error tests failed (sorry for no labels) but these are "test-isms" for local testing.
* Unit tests updated and passing

## PR Acceptance Checklist
* [X] Jira ticket acceptance criteria met.
* [X] `CHANGELOG.md` updated to include high level summary of PR changes.
* [X] (N/A) `docker/service_version.txt` updated if publishing a release.
* [X] Tests added/updated and passing.
* [X] Documentation updated (if needed).
